### PR TITLE
chore: bump deco-cx/apps to 0.147.0

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -2,7 +2,7 @@
   "imports": {
     "site/": "./",
     "deco/": "https://cdn.jsdelivr.net/gh/deco-cx/deco@1.110.0/",
-    "apps/": "https://cdn.jsdelivr.net/gh/deco-cx/apps@0.64.37/",
+    "apps/": "https://cdn.jsdelivr.net/gh/deco-cx/apps@0.151.1/",
     "$fresh/": "https://deno.land/x/fresh@1.7.3/",
     "preact": "npm:preact@10.23.1",
     "preact-render-to-string": "npm:preact-render-to-string@6.4.2",


### PR DESCRIPTION
Bumps `deco-cx/apps` to [`0.147.0`](https://github.com/deco-cx/apps/releases/tag/0.147.0).

**Release highlight:** _Migrate asset URLs to `decoims.com` (clean cutover, drop `ENABLE_AZION_ASSETS`)._

Opened as a **draft** so CI runs but the PR doesn't auto-merge. If your site uses shared image hosts (assets.decocache.com, deco-assets.edgedeco.com, etc.), this bump migrates those asset URLs to `decoims.com`. Verify image rendering on a preview deployment before marking ready-for-review.

Generated by `scripts/bump-apps-0.147.0/bump.py` (stats-lake repo).