### PR TITLE
chore: migrate legacy image URLs to decoims.com

### DIFF
--- a/apps/site.ts
+++ b/apps/site.ts
@@ -6,7 +6,7 @@ type WebsiteApp = ReturnType<typeof website>;
  * @title Site
  * @description Start your site from a template or from scratch.
  * @category Tool
- * @logo https://ozksgdmyrqcxcwhnbepg.supabase.co/storage/v1/object/public/assets/1/0ac02239-61e6-4289-8a36-e78c0975bcc8
+ * @logo https://decoims.com/als-storefront/ffa568bf-e5a3-49ed-961d-eeaa958f51b9/0ac02239-61e6-4289-8a36-e78c0975bcc8
  */
 export default function Site(state: Props): App<Manifest, Props, [
   WebsiteApp,

--- a/sections/BlogPosts.tsx
+++ b/sections/BlogPosts.tsx
@@ -26,7 +26,7 @@ export const LoadingFallback = () => {
 };
 
 const DEFAULT_IMAGE =
-  "https://ozksgdmyrqcxcwhnbepg.supabase.co/storage/v1/object/public/assets/4763/682eb374-def2-4e85-a45d-b3a7ff8a31a9";
+  "https://decoims.com/vtexadsnetwork/3cc7ca0f-aae5-4740-ad1f-f2618913c79e/682eb374-def2-4e85-a45d-b3a7ff8a31a9";
 
 export default function BlogPosts({
   title = "Here's a component for you to showcase your blogposts",

--- a/sections/Footer.tsx
+++ b/sections/Footer.tsx
@@ -51,7 +51,7 @@ export interface Props {
 export default function Footer({
   logo = {
     src:
-      "https://ozksgdmyrqcxcwhnbepg.supabase.co/storage/v1/object/public/assets/1527/67120bcd-936a-4ea5-a760-02ed5c4a3d04",
+      "https://decoims.com/vtexadsnetwork/2784ee00-6000-4be2-8f0a-3668b2d80d41/67120bcd-936a-4ea5-a760-02ed5c4a3d04",
     alt: "Logo",
   },
   links = [
@@ -96,7 +96,7 @@ export default function Footer({
   madeWith = {
     label: "Made with",
     src:
-      "https://ozksgdmyrqcxcwhnbepg.supabase.co/storage/v1/object/public/assets/1527/cc202be0-af57-4b32-b9c9-d1d7dc97bf85",
+      "https://decoims.com/vtexadsnetwork/79d1c67c-1fb3-421e-bf27-0dc0726e3d91/cc202be0-af57-4b32-b9c9-d1d7dc97bf85",
     href: "https://deco.cx",
   },
   copyright = "© 2026 Issacar Church. All rights reserved.",

--- a/sections/Header.tsx
+++ b/sections/Header.tsx
@@ -34,7 +34,7 @@ export const LoadingFallback = () => {
 export default function Header({
   logo = {
     src:
-      "https://ozksgdmyrqcxcwhnbepg.supabase.co/storage/v1/object/public/assets/1527/67120bcd-936a-4ea5-a760-02ed5c4a3d04",
+      "https://decoims.com/vtexadsnetwork/2784ee00-6000-4be2-8f0a-3668b2d80d41/67120bcd-936a-4ea5-a760-02ed5c4a3d04",
     alt: "Logo",
   },
   navigation = {

--- a/sections/Hero.tsx
+++ b/sections/Hero.tsx
@@ -45,7 +45,7 @@ export default function HeroSection({
   ctaActive = true,
   ctaTextColor = "#ffffff",
   backgroundImage =
-    "https://ozksgdmyrqcxcwhnbepg.supabase.co/storage/v1/object/public/assets/1818/6fe9404a-f69c-472a-b521-78f6c1f87326",
+    "https://decoims.com/oscarcalcados/e9e2c963-276d-4b87-814a-e8b041091a3b/6fe9404a-f69c-472a-b521-78f6c1f87326",
 }: Props) {
   return (
     <div class="relative h-screen flex items-center justify-center text-center">

--- a/sections/IASection.tsx
+++ b/sections/IASection.tsx
@@ -63,28 +63,28 @@ export default function ProductShelfSlider({
   products = [
     {
       image:
-        "https://ozksgdmyrqcxcwhnbepg.supabase.co/storage/v1/object/public/assets/1818/ff6bb37e-0eab-40e1-a454-86856efc278e",
+        "https://decoims.com/als-storefront/08b81bf2-89e6-4ea4-8123-b0b1bee1f7be/ff6bb37e-0eab-40e1-a454-86856efc278e",
       name: "Product 1",
       price: 19.99,
       purchaseUrl: "#",
     },
     {
       image:
-        "https://ozksgdmyrqcxcwhnbepg.supabase.co/storage/v1/object/public/assets/1818/ff6bb37e-0eab-40e1-a454-86856efc278e",
+        "https://decoims.com/als-storefront/08b81bf2-89e6-4ea4-8123-b0b1bee1f7be/ff6bb37e-0eab-40e1-a454-86856efc278e",
       name: "Product 2",
       price: 24.99,
       purchaseUrl: "#",
     },
     {
       image:
-        "https://ozksgdmyrqcxcwhnbepg.supabase.co/storage/v1/object/public/assets/1818/ff6bb37e-0eab-40e1-a454-86856efc278e",
+        "https://decoims.com/als-storefront/08b81bf2-89e6-4ea4-8123-b0b1bee1f7be/ff6bb37e-0eab-40e1-a454-86856efc278e",
       name: "Product 3",
       price: 29.99,
       purchaseUrl: "#",
     },
     {
       image:
-        "https://ozksgdmyrqcxcwhnbepg.supabase.co/storage/v1/object/public/assets/1818/ff6bb37e-0eab-40e1-a454-86856efc278e",
+        "https://decoims.com/als-storefront/08b81bf2-89e6-4ea4-8123-b0b1bee1f7be/ff6bb37e-0eab-40e1-a454-86856efc278e",
       name: "Product 4",
       price: 34.99,
       purchaseUrl: "#",

--- a/sections/ImageWithParagraph.tsx
+++ b/sections/ImageWithParagraph.tsx
@@ -58,7 +58,7 @@ export function ErrorFallback(
 }
 
 const DEFAULT_IMAGE =
-  "https://ozksgdmyrqcxcwhnbepg.supabase.co/storage/v1/object/public/assets/4763/772e246e-1959-46ac-a309-3f25ab20af6f";
+  "https://decoims.com/vtexadsnetwork/cdace7b3-72ec-410d-bcbf-7761a1f6e951/772e246e-1959-46ac-a309-3f25ab20af6f";
 
 export default function ImageWithParagraph({
   title = "Here's an intermediate size heading you can edit",

--- a/sections/Logos.tsx
+++ b/sections/Logos.tsx
@@ -15,7 +15,7 @@ export interface Props {
 
 const IMG_PLACEHODLER = Array(30).fill(0).map(() => ({
   src:
-    "https://ozksgdmyrqcxcwhnbepg.supabase.co/storage/v1/object/public/assets/1527/03fbcc78-ca86-4616-a59a-b8aa18331a9c",
+    "https://decoims.com/vtexadsnetwork/2fd1bde8-63c3-4ee3-96ae-3676ed7e6911/03fbcc78-ca86-4616-a59a-b8aa18331a9c",
   altText: "Logo",
 }));
 

--- a/sections/Testimonials.tsx
+++ b/sections/Testimonials.tsx
@@ -54,7 +54,7 @@ const DEFAULT_PROPS = {
         description:
           "Showcase customer feedback that emphasizes your product or service's key features and addresses prospective clients' concerns. Display endorsements from customer groups that mirror your target audience.",
         avatar:
-          "https://ozksgdmyrqcxcwhnbepg.supabase.co/storage/v1/object/public/assets/1527/7286de42-e9c5-4fcb-ae8b-b992eea4b78e",
+          "https://decoims.com/vtexadsnetwork/6c967ed3-04ac-4bd1-9eeb-a108d567e205/7286de42-e9c5-4fcb-ae8b-b992eea4b78e",
         alt: "Avatar",
         name: "Name Surname",
         position: "Position, Company name",
@@ -65,7 +65,7 @@ const DEFAULT_PROPS = {
         description:
           "Showcase customer feedback that emphasizes your product or service's key features and addresses prospective clients' concerns. Display endorsements from customer groups that mirror your target audience.",
         avatar:
-          "https://ozksgdmyrqcxcwhnbepg.supabase.co/storage/v1/object/public/assets/1527/7286de42-e9c5-4fcb-ae8b-b992eea4b78e",
+          "https://decoims.com/vtexadsnetwork/6c967ed3-04ac-4bd1-9eeb-a108d567e205/7286de42-e9c5-4fcb-ae8b-b992eea4b78e",
         alt: "Avatar",
         name: "Name Surname",
         position: "Position, Company name",
@@ -76,7 +76,7 @@ const DEFAULT_PROPS = {
         description:
           "Showcase customer feedback that emphasizes your product or service's key features and addresses prospective clients' concerns. Display endorsements from customer groups that mirror your target audience.",
         avatar:
-          "https://ozksgdmyrqcxcwhnbepg.supabase.co/storage/v1/object/public/assets/1527/7286de42-e9c5-4fcb-ae8b-b992eea4b78e",
+          "https://decoims.com/vtexadsnetwork/6c967ed3-04ac-4bd1-9eeb-a108d567e205/7286de42-e9c5-4fcb-ae8b-b992eea4b78e",
         alt: "Avatar",
         name: "Name Surname",
         position: "Position, Company name",
@@ -87,7 +87,7 @@ const DEFAULT_PROPS = {
         description:
           "Showcase customer feedback that emphasizes your product or service's key features and addresses prospective clients' concerns. Display endorsements from customer groups that mirror your target audience.",
         avatar:
-          "https://ozksgdmyrqcxcwhnbepg.supabase.co/storage/v1/object/public/assets/1527/7286de42-e9c5-4fcb-ae8b-b992eea4b78e",
+          "https://decoims.com/vtexadsnetwork/6c967ed3-04ac-4bd1-9eeb-a108d567e205/7286de42-e9c5-4fcb-ae8b-b992eea4b78e",
         alt: "Avatar",
         name: "Name Surname",
         position: "Position, Company name",
@@ -98,7 +98,7 @@ const DEFAULT_PROPS = {
         description:
           "Showcase customer feedback that emphasizes your product or service's key features and addresses prospective clients' concerns. Display endorsements from customer groups that mirror your target audience.",
         avatar:
-          "https://ozksgdmyrqcxcwhnbepg.supabase.co/storage/v1/object/public/assets/1527/7286de42-e9c5-4fcb-ae8b-b992eea4b78e",
+          "https://decoims.com/vtexadsnetwork/6c967ed3-04ac-4bd1-9eeb-a108d567e205/7286de42-e9c5-4fcb-ae8b-b992eea4b78e",
         alt: "Avatar",
         name: "Name Surname",
         position: "Position, Company name",

--- a/sections/hero-1.tsx
+++ b/sections/hero-1.tsx
@@ -34,17 +34,17 @@ export default function ImageGallery({
   images = [
     {
       image:
-        "https://ozksgdmyrqcxcwhnbepg.supabase.co/storage/v1/object/public/assets/1818/ff6bb37e-0eab-40e1-a454-86856efc278e",
+        "https://decoims.com/als-storefront/08b81bf2-89e6-4ea4-8123-b0b1bee1f7be/ff6bb37e-0eab-40e1-a454-86856efc278e",
       alt: "Image 1",
     },
     {
       image:
-        "https://ozksgdmyrqcxcwhnbepg.supabase.co/storage/v1/object/public/assets/1818/ff6bb37e-0eab-40e1-a454-86856efc278e",
+        "https://decoims.com/als-storefront/08b81bf2-89e6-4ea4-8123-b0b1bee1f7be/ff6bb37e-0eab-40e1-a454-86856efc278e",
       alt: "Image 2",
     },
     {
       image:
-        "https://ozksgdmyrqcxcwhnbepg.supabase.co/storage/v1/object/public/assets/1818/ff6bb37e-0eab-40e1-a454-86856efc278e",
+        "https://decoims.com/als-storefront/08b81bf2-89e6-4ea4-8123-b0b1bee1f7be/ff6bb37e-0eab-40e1-a454-86856efc278e",
       alt: "Image 3",
     },
   ],


### PR DESCRIPTION
Migração automática de URLs de imagens legadas para decoims.com.

- Substituição de domínios legados (`assets.decocache.com` etc.) por `decoims.com`
- Apenas substituição de strings nos arquivos de configuração/blocos

**Não fazer merge sem revisão.**